### PR TITLE
Added strdup() to creation of label for testcase and unittest

### DIFF
--- a/src/qtest/src/testcase.c
+++ b/src/qtest/src/testcase.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h> // For strdup()
 
 #include "qtest/testsuite.h"
 #include "testcase_p.h"
@@ -12,7 +13,7 @@ qtestcase_t * create_qtestcase(char * label) {
         exit(-1);
     }
 
-    testcase->label = label;
+    testcase->label = strdup(label);
     testcase->result = FAILED;
     testcase->next = NULL;
     return testcase;

--- a/src/qtest/src/unittest.c
+++ b/src/qtest/src/unittest.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h> // For strdup()
 
 #include "qtest/testsuite.h"
 #include "unittest_p.h"
@@ -13,7 +14,7 @@ qunittest_t * create_qunittest(char * label) {
         exit(-1);
     }
 
-    unittest->label = label;
+    unittest->label = strdup(label);
     unittest->length = 0;
     unittest->first = NULL;
     return unittest;


### PR DESCRIPTION
Allows tests to be iterated through. E.g. using loop to create a series of tests for each element of an array. The label for each test in the array can be created at runtime using strformat() but is then out of scope when qtest tries to print. Using strdup ensures scope is maintained until the end of qtest.